### PR TITLE
Add a basic CSharp section

### DIFF
--- a/rules/0230-CSharp.md
+++ b/rules/0230-CSharp.md
@@ -1,1 +1,11 @@
-<!--- this is only a placeholder -->
+## CSharp
+CSharp is the only language that doesn't have a proper documentation on Codewars
+currently. This will probably change at some point. The test framework is
+[NUnit](http://www.nunit.org/), initially a port from JUnit. It's rather large,
+so we cannot cover [everything][Nunit doc] here, but at least some points
+should be addressed.
+
+*Note:* C# looks rather ugly in the generated PDF, so I'm going to refer to it
+as _CSharp_ instead.
+
+ [Nunit doc]: http://www.nunit.org/index.php?p=docHome&r=2.6.4

--- a/rules/0230-CSharp.md
+++ b/rules/0230-CSharp.md
@@ -48,7 +48,9 @@ Test.assert_equals(actual, expected, message)
 ```
 
 Keep this in mind. Your tests won't fail if your swap the arguments, but they
-__will__ confuse anyone who fails to pass your assertion.
+__will__ confuse anyone who fails to pass your assertion. By the way, Java
+uses the same convention. This isn't surprising, since NUnit was inspired by
+JUnit.
 
  [Assert]: http://www.nunit.org/index.php?p=equalityAsserts&r=2.6.4
 

--- a/rules/0230-CSharp.md
+++ b/rules/0230-CSharp.md
@@ -52,3 +52,11 @@ __will__ confuse anyone who fails to pass your assertion.
 
  [Assert]: http://www.nunit.org/index.php?p=equalityAsserts&r=2.6.4
 
+### Use descriptive test names
+This was already addressed in the previous section, but it's rather important
+in CSharp. NUnit doesn't give you any method to label a test. Instead, a test
+is simply a public static method with a `[Test]` attribute inside a class with
+the `[TestFixture]` attribute. The _name_ of your test is the method's name.
+
+Make that name descriptive. A method called `test1` doesn't help.
+

--- a/rules/0230-CSharp.md
+++ b/rules/0230-CSharp.md
@@ -60,3 +60,62 @@ the `[TestFixture]` attribute. The _name_ of your test is the method's name.
 
 Make that name descriptive. A method called `test1` doesn't help.
 
+### Use `[TestCase]` for multiple test cases
+The [TestCase] attribute enables you to specify the arguments for a test
+function. This works best if you use `TestCase` together with `Result`:
+
+ [TestCase]: http://www.nunit.org/index.php?p=testCase&r=2.6.4
+
+```csharp
+[Test]
+[TestCase(2, Result=true)]
+[TestCase(4, Result=true)]
+[TestCase(6, Result=true)]
+[TestCase(-10, Result=true)]
+public static bool ReturnsTrueOnEven(int n){
+  return Evener.isEven(n);
+}
+
+[Test]
+[TestCase(3, Result=false)]
+[TestCase(5, Result=false)]
+[TestCase(7, Result=false)]
+[TestCase(-1, Result=false)]
+public static bool ReturnsFalseOnOdd(int n){
+  return Evener.isEven(n);
+}
+```
+
+### Use `[Random]` for simple random values
+The `Random` attribute can be used on arguments. This enables you to create
+random integers or doubles within a range:
+
+```csharp
+[Test]
+public static void RandomTests([Random(10, 500000, 100)] int n)) {
+    Assert.AreEqual(PersistTests.Sol(n), Persist.Persistence(n));
+}
+```
+This would draw random integers between 10 and 500000 (inclusive) and run a
+total of 100 tests.
+
+### Use `[Theory]` for a QuickCheck light experience
+Haskell's QuickCheck enables you to test only certain combinations of random
+values via `forAll`. That's also possible with `[Theory]` and `Assume`:
+
+```csharp
+[Theory]
+public static void ReturnsTrueOnEven([Random(1, 50000, 100)] int n){
+  Assume.That(n % 2 == 0);
+  Assert.That(Evener.isEven(n));
+}
+
+[Theory]
+public static void ReturnsFalseOnOdd([Random(1, 50000, 100)] int n){
+  Assume.That(n % 2 == 1);
+  Assert.That(! Evener.isEven(n));
+}
+```
+However, this should be used with care. After all, NUnit will still check only
+100 random values, and if they don't hold the assumption, the test case is
+still completely executed but any failed assertion is disregarded.

--- a/rules/0230-CSharp.md
+++ b/rules/0230-CSharp.md
@@ -9,3 +9,46 @@ should be addressed.
 as _CSharp_ instead.
 
  [Nunit doc]: http://www.nunit.org/index.php?p=docHome&r=2.6.4
+
+### Beware of the assert arguments!
+NUnit differs from the other frameworks. Very. Much. Well, overall it doesn't,
+it still has it's `Assert.AreEqual` and `Assert.Greater` and others. __But__ the
+order of arguments is swapped.
+
+Where CoffeeScript, Ruby, Python and Haskell expect the first argument of
+`Test.assert_equals`/`Test.assertEquals`/`shouldBe` to be the actual value and
+the second to be the expected, NUnit swaps the order, see the documentation of
+[Assert]:
+
+``` charp
+Assert.AreEqual( int expected, int actual );
+Assert.AreEqual( int expected, int actual, string message );
+Assert.AreEqual( int expected, int actual, string message,
+                 params object[] parms );
+// many other
+```
+
+For comparison, here's the syntax of an equality assert in the other languages:
+
+``` haskell
+-- Haskell
+actual `shouldBe` expected
+```
+``` javascript
+// Javascript
+Test.assertEquals(actual, expected, message);
+```
+``` python
+# Python
+Test.assert_equals(actual, expected, message)
+```
+``` ruby
+# Ruby
+Test.assert_equals(actual, expected, message)
+```
+
+Keep this in mind. Your tests won't fail if your swap the arguments, but they
+__will__ confuse anyone who fails to pass your assertion.
+
+ [Assert]: http://www.nunit.org/index.php?p=equalityAsserts&r=2.6.4
+

--- a/rules/0230-CSharp.md
+++ b/rules/0230-CSharp.md
@@ -12,7 +12,7 @@ as _CSharp_ instead.
 
 ### Beware of the assert arguments!
 NUnit differs from the other frameworks. Very. Much. Well, overall it doesn't,
-it still has it's `Assert.AreEqual` and `Assert.Greater` and others. __But__ the
+it still has `Assert.AreEqual`, `Assert.Greater` and others. But the
 order of arguments is swapped.
 
 Where CoffeeScript, Ruby, Python and Haskell expect the first argument of
@@ -47,23 +47,27 @@ Test.assert_equals(actual, expected, message)
 Test.assert_equals(actual, expected, message)
 ```
 
-Keep this in mind. Your tests won't fail if your swap the arguments, but they
-__will__ confuse anyone who fails to pass your assertion. By the way, Java
+Keep this in mind. Your tests won't fail on correct solutions if you swap the
+arguments, but they __will__ confuse anyone who fails them. By the way, Java
 uses the same convention. This isn't surprising, since NUnit was inspired by
 JUnit.
 
  [Assert]: http://www.nunit.org/index.php?p=equalityAsserts&r=2.6.4
 
 ### Use descriptive test names
-This was already addressed in the previous section, but it's rather important
+This was already addressed in the previous chapter, but it's rather important
 in CSharp. NUnit doesn't give you any method to label a test. Instead, a test
 is simply a public static method with a `[Test]` attribute inside a class with
 the `[TestFixture]` attribute. The _name_ of your test is the method's name.
 
-Make that name descriptive. A method called `test1` doesn't help.
+Make that name descriptive. A method called `test1` doesn't help. Name it after
+the property you're testing, e.g. `ReturnsTrueOnEven`, or
+`ThrowsExceptionOnNull`.
 
-### Use `[TestCase]` for multiple test cases
-The [TestCase] attribute enables you to specify the arguments for a test
+### Use `[TestCase]` to create parametrized tests
+A test function doesn't have to be of type `void ...(void)`. You can use
+parameters, which will be shown automatically. This is possible via the
+[TestCase] attribute. It enables you to specify the arguments for a test
 function. This works best if you use `TestCase` together with `Result`:
 
  [TestCase]: http://www.nunit.org/index.php?p=testCase&r=2.6.4
@@ -87,9 +91,10 @@ public static bool ReturnsFalseOnOdd(int n){
   return Evener.isEven(n);
 }
 ```
+You can also use your regular `Assert.*` functions instead.
 
 ### Use `[Random]` for simple random values
-The `Random` attribute can be used on arguments. This enables you to create
+The [Random] attribute can be used on arguments. This enables you to create
 random integers or doubles within a range:
 
 ```csharp
@@ -101,9 +106,11 @@ public static void RandomTests([Random(10, 500000, 100)] int n)) {
 This would draw random integers between 10 and 500000 (inclusive) and run a
 total of 100 tests.
 
+ [Random]: http://www.nunit.org/index.php?p=random&r=2.6.4
+
 ### Use `[Theory]` for a QuickCheck light experience
 Haskell's QuickCheck enables you to test only certain combinations of random
-values via `forAll`. That's also possible with `[Theory]` and `Assume`:
+values via `forAll`. That's also possible with [Theory] and `Assume`:
 
 ```csharp
 [Theory]
@@ -121,3 +128,5 @@ public static void ReturnsFalseOnOdd([Random(1, 50000, 100)] int n){
 However, this should be used with care. After all, NUnit will still check only
 100 random values, and if they don't hold the assumption, the test case is
 still completely executed but any failed assertion is disregarded.
+
+ [Theory]: http://www.nunit.org/index.php?p=theory&r=2.6.4

--- a/rules/0240-Haskell.md
+++ b/rules/0240-Haskell.md
@@ -2,8 +2,8 @@ Haskell
 -------
 
 [Haskell](http://www.haskell.org) has been my main translation target on
-Codewars so far, so it's probably fair that I start with it. [QuickCheck]
-makes it rather easy to create random tests, and Hspec provides a very easy
+Codewars so far, so it's probably the one I know most. [QuickCheck] makes it #
+tremendously easy to create random tests, and Hspec provides a very convenient
 test framework.
 
 Codewars has QuickCheck, [Hspec] and [HUnit] installed. Unfortunately, it

--- a/rules/0240-Haskell.md
+++ b/rules/0240-Haskell.md
@@ -2,7 +2,7 @@ Haskell
 -------
 
 [Haskell](http://www.haskell.org) has been my main translation target on
-Codewars so far, so it's probably the one I know most. [QuickCheck] makes it #
+Codewars so far, so it's probably the one I know most. [QuickCheck] makes it
 tremendously easy to create random tests, and Hspec provides a very convenient
 test framework.
 

--- a/rules/0260-JavaScript.md
+++ b/rules/0260-JavaScript.md
@@ -1,8 +1,17 @@
-JavaScript
-----------
+JavaScript / CoffeeScript
+-------------------------
 
-*This section is under construction. Beware of the dragon, ye who enter his
-lair*.
+The JavaScript tests on CodeWars use a [custom] test framework. Any kata written
+in CoffeeScript will use the same framework, since CoffeeScript gets compiled
+to JavaScript.
+
+Therefore, you won't find a section about CoffeeScript in this document. Also,
+keep in mind that the current support of ES2015 is implemented via [Babel], so
+you won't get the real source code if you use `.toString()`, but the result of
+the Babel compiler.
+
+ [custom]: http://www.codewars.com/docs/js-slash-coffeescript-test-reference
+ [Babel]: https://babeljs.io/
 
 ### Floating point tests
 


### PR DESCRIPTION
As there is no CSharp section in Codewars at the moment, there should at least be a basic one in this document. It should contain the following features:
- [x] links to NUnit
- common misconceptions
  - [x] wrong order of arguments
  - [x] bad test names
  - [x] ???
- slightly advanced tricks
  - [x] `[TestCase]`
  - [x] `[Random]`
  - [x] `[Theory]`

Merging this pull-request would also fix #11.
